### PR TITLE
Continuous Deployment to gh-pages from circle-ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,11 @@
 # Check https://circleci.com/docs/2.0/language-javascript/ for more details
 #
 version: 2
+
+branches:
+  ignore:
+    - gh-pages
+
 jobs:
   test:
     docker:
@@ -40,9 +45,28 @@ jobs:
       - run: npm install
       - run: npm run build
 
+  deploy:
+    docker:
+      - image: circleci/node:9.11.2
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+      - run: npm install
+      - run: npm run deploy
+
 workflows:
   version: 2
   test-and-build:
     jobs:
       - test
       - build
+      - deploy:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "ProjectBoilerplate",
+  "name": "Piccolo",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "predeploy": "npm run build",
-    "deploy": "gh-pages -b master -d build",
+    "deploy": "gh-pages -d build",
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "jest",


### PR DESCRIPTION
# What has changed and why?

Automatic deployment each time we merge to master.
Circle-ci runs on any branch change. If the branch is the `master` branch, the deploy task will run, which publishes a build to github pages. (see readme for what those are)


# How to test this change

- [x] has automated tests
- [ ] at least one a reviewer ran the code
- [ ] tested in small screen
- [ ] i18n
- [ ] tested in screen reader/contrast <-- remove this if no UX change
