### PR TITLE
Corrected ages in description for Uruguay pensions

### DIFF
--- a/src/__tests__/components/__snapshots__/SectionFive.test.js.snap
+++ b/src/__tests__/components/__snapshots__/SectionFive.test.js.snap
@@ -284,7 +284,7 @@ exports[`SectionFive renders correctly 1`] = `
           <li
             className="c9"
           >
-            Eligibility is determined by age and contributions to social security related to labor.
+            Eligibility is determined by age and contributions to social security related to labour.
           </li>
           <li
             className="c9"

--- a/src/__tests__/components/__snapshots__/SectionFive.test.js.snap
+++ b/src/__tests__/components/__snapshots__/SectionFive.test.js.snap
@@ -294,7 +294,7 @@ exports[`SectionFive renders correctly 1`] = `
           <li
             className="c9"
           >
-            There are two stages of pensions; one at age 62 for women and 67 for men, and a second age pension at 70 which has less eligibility requirements than the first age pension.
+            There are two stages of pensions; one at age 60, and a second advanced age pension at 70 which has less eligibility requirements than the first age pension.
           </li>
           <li
             className="c9"

--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -33,7 +33,7 @@ const countries = [
     eligibility_list: [
       'Eligibility is determined by age and contributions to social security related to labor.',
       'You must have completed 30 years of work.',
-      'There are two stages of pensions; one at age 62 for women and 67 for men, and a second age pension at 70 which has less eligibility requirements than the first age pension.',
+      'There are two stages of pensions; one at age 60, and a second advanced age pension at 70 which has less eligibility requirements than the first age pension.',
       'For women each child (up to max of 5) counts as a \'year of work\'.'
     ]
   }

--- a/src/data/countries.js
+++ b/src/data/countries.js
@@ -31,7 +31,7 @@ const countries = [
     eligible_key: 'edad_de_jubilacion',
     subtitle: 'Government pensions for work retirement are called Jubilaciones.',
     eligibility_list: [
-      'Eligibility is determined by age and contributions to social security related to labor.',
+      'Eligibility is determined by age and contributions to social security related to labour.',
       'You must have completed 30 years of work.',
       'There are two stages of pensions; one at age 60, and a second advanced age pension at 70 which has less eligibility requirements than the first age pension.',
       'For women each child (up to max of 5) counts as a \'year of work\'.'


### PR DESCRIPTION
# What has changed and why?

The description of Uruguay's pension had the wrong ages in it. 

# How to test this change

Run the app yourself, see the new text on page

- [x] has automated tests
- [ ] at least one a reviewer ran the code
- [x] tested in small screen
- [ ] i18n
- [x] tested in screen reader/contrast <-- remove this if no UX change
