### PR TITLE
Feature/hide madlib until all entries are filled

### DIFF
--- a/src/__tests__/components/__snapshots__/Madlib.test.js.snap
+++ b/src/__tests__/components/__snapshots__/Madlib.test.js.snap
@@ -38,6 +38,12 @@ exports[`Madlib renders correctly 1`] = `
 }
 
 @media (min-width:1024px) {
+  .c1 {
+    height: auto;
+  }
+}
+
+@media (min-width:1024px) {
   .c0 > p {
     font-size: 34px;
   }
@@ -52,74 +58,72 @@ exports[`Madlib renders correctly 1`] = `
 <div
   className="c0"
 >
-  <div>
-    <p
-      className="c1"
-    >
-      I am a
-    </p>
-    <input
-      className="c2"
-      defaultValue="woman"
-      readOnly={true}
-      style={
-        Object {
-          "width": "130px",
-        }
+  <p
+    className="c1"
+  >
+    I am a
+  </p>
+  <input
+    className="c2"
+    defaultValue="woman"
+    readOnly={true}
+    style={
+      Object {
+        "width": "130px",
       }
-      type="text"
-    />
-    <br />
-    <p
-      className="c1"
-    >
-      who has had
-    </p>
-    <input
-      className="c2"
-      defaultValue={5}
-      readOnly={true}
-      type="text"
-    />
-    <p
-      className="c1"
-    >
-      children.
-    </p>
-    <br />
-    <p
-      className="c1"
-    >
-      I have lived in the country for
-    </p>
-    <input
-      className="c2"
-      defaultValue={40}
-      readOnly={true}
-      type="text"
-    />
-    <p
-      className="c1"
-    >
-       years, 
-    </p>
-    <br />
-    <p
-      className="c1"
-    >
-       and worked there for 
-    </p>
-    <input
-      className="c2"
-      defaultValue={55}
-      readOnly={true}
-      type="text"
-    />
-    <p
-      className="c1"
-    >
-       years.
-    </p>
-  </div>
+    }
+    type="text"
+  />
+  <br />
+  <p
+    className="c1"
+  >
+    who has had
+  </p>
+  <input
+    className="c2"
+    defaultValue={5}
+    readOnly={true}
+    type="text"
+  />
+  <p
+    className="c1"
+  >
+    children.
+  </p>
+  <br />
+  <p
+    className="c1"
+  >
+    I have lived in the country for
+  </p>
+  <input
+    className="c2"
+    defaultValue={40}
+    readOnly={true}
+    type="text"
+  />
+  <p
+    className="c1"
+  >
+     years, 
+  </p>
+  <br />
+  <p
+    className="c1"
+  >
+     and worked there for 
+  </p>
+  <input
+    className="c2"
+    defaultValue={55}
+    readOnly={true}
+    type="text"
+  />
+  <p
+    className="c1"
+  >
+     years.
+  </p>
 </div>
 `;

--- a/src/__tests__/components/__snapshots__/SectionFive.test.js.snap
+++ b/src/__tests__/components/__snapshots__/SectionFive.test.js.snap
@@ -6,7 +6,7 @@ exports[`SectionFive renders correctly 1`] = `
   color: #000;
   line-height: 1.5;
   font-size: 24px;
-  height: 55px;
+  height: 100%;
 }
 
 .c7 {
@@ -118,9 +118,27 @@ exports[`SectionFive renders correctly 1`] = `
   margin-bottom: 18px;
 }
 
+@media (min-width:1024px) {
+  .c5 {
+    height: 55px;
+  }
+}
+
+@media (min-width:1024px) {
+  .c7 {
+    height: auto;
+  }
+}
+
+@media (min-width:1024px) {
+  .c1 {
+    width: 88%;
+  }
+}
+
 @media (min-width:1440px) {
   .c1 {
-    width: 55%;
+    width: 65%;
   }
 }
 

--- a/src/__tests__/elements/Paragraph.test.js
+++ b/src/__tests__/elements/Paragraph.test.js
@@ -40,5 +40,5 @@ test('Paragraph height should be adjusted', () => {
   const tree = renderer.create(<Paragraph light adjust />).toJSON();
   expect(tree).toMatchSnapshot();
   expect(tree).toHaveStyleRule('color', '#fff');
-  expect(tree).toHaveStyleRule('height', '55px');
+  expect(tree).toHaveStyleRule('height', '100%');
 });

--- a/src/__tests__/elements/__snapshots__/Container.test.js.snap
+++ b/src/__tests__/elements/__snapshots__/Container.test.js.snap
@@ -6,9 +6,15 @@ exports[`Container renders correctly 1`] = `
   width: 75%;
 }
 
+@media (min-width:1024px) {
+  .c0 {
+    width: 88%;
+  }
+}
+
 @media (min-width:1440px) {
   .c0 {
-    width: 55%;
+    width: 65%;
   }
 }
 

--- a/src/__tests__/elements/__snapshots__/Paragraph.test.js.snap
+++ b/src/__tests__/elements/__snapshots__/Paragraph.test.js.snap
@@ -9,6 +9,12 @@ exports[`Paragraph colour should be light if specified 1`] = `
   height: auto;
 }
 
+@media (min-width:1024px) {
+  .c0 {
+    height: auto;
+  }
+}
+
 <p
   className="c0"
 />
@@ -22,6 +28,12 @@ exports[`Paragraph default styles applied 1`] = `
   height: auto;
 }
 
+@media (min-width:1024px) {
+  .c0 {
+    height: auto;
+  }
+}
+
 <p
   className="c0"
 />
@@ -33,7 +45,13 @@ exports[`Paragraph height should be adjusted 1`] = `
   color: #000;
   line-height: 1.5;
   color: #fff;
-  height: 55px;
+  height: 100%;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    height: 55px;
+  }
 }
 
 <p
@@ -50,6 +68,12 @@ exports[`Paragraph large styles applied 1`] = `
   height: auto;
 }
 
+@media (min-width:1024px) {
+  .c0 {
+    height: auto;
+  }
+}
+
 <p
   className="c0"
 />
@@ -64,6 +88,12 @@ exports[`Paragraph medium styles applied 1`] = `
   height: auto;
 }
 
+@media (min-width:1024px) {
+  .c0 {
+    height: auto;
+  }
+}
+
 <p
   className="c0"
 />
@@ -76,6 +106,12 @@ exports[`Paragraph small styles applied 1`] = `
   line-height: 1.5;
   font-size: 22px;
   height: auto;
+}
+
+@media (min-width:1024px) {
+  .c0 {
+    height: auto;
+  }
 }
 
 <p

--- a/src/__tests__/page/__snapshots__/Header.test.js.snap
+++ b/src/__tests__/page/__snapshots__/Header.test.js.snap
@@ -18,9 +18,21 @@ exports[`SectionHeader renders correctly 1`] = `
   height: auto;
 }
 
+@media (min-width:1024px) {
+  .c0 {
+    width: 88%;
+  }
+}
+
 @media (min-width:1440px) {
   .c0 {
-    width: 55%;
+    width: 65%;
+  }
+}
+
+@media (min-width:1024px) {
+  .c2 {
+    height: auto;
   }
 }
 

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -102,7 +102,6 @@ class App extends Component {
         <SectionThree
           values={this.state}
         />
-        <SectionFour />
         {this.state.israel_results && this.state.new_zealand_results && <SectionFive
           israel={this.state.israel_results && this.state.israel_results}
           new_zealand={this.state.new_zealand_results && this.state.new_zealand_results}

--- a/src/components/Madlib.js
+++ b/src/components/Madlib.js
@@ -39,19 +39,19 @@ const Input = styled.input.attrs({ type: 'text' })`
 `;
 
 const MadLib = props => <MadLibWrapper>
-  {props.values && <div><Paragraph>I am a</Paragraph>
-    <Input readOnly style={{ width: '130px' }} defaultValue={props.values.gender} /><br />
-    <Fragment>
-      <Paragraph>who has had</Paragraph>
-      <Input readOnly defaultValue={props.values.number_of_children} />
-      <Paragraph>children.</Paragraph><br />
-    </Fragment>
-    <Paragraph>I have lived in the country for</Paragraph>
-    <Input readOnly defaultValue={props.values.years_lived_in_country} />
-    <Paragraph> years, </Paragraph><br />
-    <Paragraph> and worked there for </Paragraph>
-    <Input readOnly defaultValue={props.values.years_worked} />
-    <Paragraph> years.</Paragraph></div>}
+  <Paragraph>I am a</Paragraph>
+  <Input readOnly style={{ width: '130px' }} defaultValue={props.values.gender} /><br />
+  <Fragment>
+    <Paragraph>who has had</Paragraph>
+    <Input readOnly defaultValue={props.values.number_of_children} />
+    <Paragraph>children.</Paragraph><br />
+  </Fragment>
+  <Paragraph>I have lived in the country for</Paragraph>
+  <Input readOnly defaultValue={props.values.years_lived_in_country} />
+  <Paragraph> years, </Paragraph><br />
+  <Paragraph> and worked there for </Paragraph>
+  <Input readOnly defaultValue={props.values.years_worked} />
+  <Paragraph> years.</Paragraph>
 </MadLibWrapper>;
 
 export default MadLib;

--- a/src/elements/Container.js
+++ b/src/elements/Container.js
@@ -3,8 +3,11 @@ import styled from 'styled-components';
 const Container = styled.div`
   margin: 0 auto;
   width: 75%;
+  @media(min-width: 1024px) {
+    width: 88%;
+  }
   @media(min-width: 1440px) {
-    width: 55%;
+    width: 65%;
   }
 `;
 

--- a/src/elements/Grid.js
+++ b/src/elements/Grid.js
@@ -26,10 +26,6 @@ export const Column = styled.div`
     padding-bottom: 0;
   }
 
-  // @media(min-width: 325px) {
-  //   padding: 0 40px 10px 40px;
-  // }
-
   @media(min-width: 1024px) {
     flex: 1;
     border-left: 1px solid #000;

--- a/src/elements/Grid.js
+++ b/src/elements/Grid.js
@@ -25,6 +25,11 @@ export const Column = styled.div`
     margin-bottom: 0;
     padding-bottom: 0;
   }
+
+  // @media(min-width: 325px) {
+  //   padding: 0 40px 10px 40px;
+  // }
+
   @media(min-width: 1024px) {
     flex: 1;
     border-left: 1px solid #000;

--- a/src/elements/Paragraph.js
+++ b/src/elements/Paragraph.js
@@ -17,7 +17,11 @@ const Paragraph = styled.p`
     color: #fff;
   `}
 
-  height: ${props => (props.adjust ? '55px' : 'auto')};
+  height: ${props => (props.adjust ? '100%' : 'auto')};
+
+  @media(min-width: 1024px) {
+    height: ${props => (props.adjust ? '55px' : 'auto')};
+  }
 `;
 
 export default Paragraph;

--- a/src/page/Sections.js
+++ b/src/page/Sections.js
@@ -28,13 +28,16 @@ const EligibleHeader = props => <Paragraph medium adjust>
   You are eligible for a pension at age <span>{props.age}</span>
 </Paragraph>;
 
-export const SectionThree = props => <div style={{ display: props.show }}><Section light>
-  <Container>
-    <MadLib
-      values={props.values}
-    />
-  </Container>
-</Section></div>;
+export const SectionThree = props => <Fragment>
+  {props.values.number_of_children && props.values.years_worked && props.values.years_lived_in_country && props.values.gender && <Fragment>
+    <Section light>
+      <Container>
+        <MadLib values={props.values} />
+      </Container>
+    </Section>
+    <SectionFour />
+  </Fragment>}
+</Fragment>;
 
 export const SectionFour = props => <div style={{ display: props.show }}><Section dark>
   <Container>


### PR DESCRIPTION
# What has changed and why?
Hide the madlib until all fields are filled.

# How to test this change
 - Madlib should not be visible
 - Fill in the input fields
 - Madlib and results should appear
- [ ] has automated tests
- [ ] at least one a reviewer ran the code
- [ ] tested in small screen
- [ ] i18n
- [ ] tested in screen reader/contrast <-- remove this if no UX change
